### PR TITLE
Do not explicitly remove the python-pip package

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -9,4 +9,3 @@ package_names:
   # want /usr/bin/python to not exist, since if it does then Ansible
   # will use it as its python.
   - python-minimal
-  - python-pip

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -6,4 +6,3 @@ package_names:
   - python-unversioned-command
   - python2
   - python2-devel
-  - python2-pip


### PR DESCRIPTION
## 🗣 Description

This pull request makes the change of not explicitly removing the `python-pip` package.

## 💭 Motivation and Context

This package does not exist in Debian Bullseye or Kali, and in the cases where it does exist it gets removed by autoremove.  So there is no need to list it explicitly.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
