### PR TITLE
Preserve python2 on Debian 9

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for review when someone
 # opens a pull request.
-*       @dav3r @felddy @hillaryj @jsf9k @mcdonnnj @cisagov/team-ois
+* @dav3r @jsf9k @mcdonnnj

--- a/.github/lineage.yml
+++ b/.github/lineage.yml
@@ -3,4 +3,4 @@ version: "1"
 
 lineage:
   skeleton:
-    remote-url: https://github.com/cisagov/skeleton-generic.git
+    remote-url: https://github.com/cisagov/skeleton-ansible-role.git

--- a/.github/lineage.yml
+++ b/.github/lineage.yml
@@ -1,0 +1,6 @@
+---
+version: "1"
+
+lineage:
+  skeleton:
+    remote-url: https://github.com/cisagov/skeleton-generic.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,11 @@
 ---
 name: build
 
-on: [
-  push,
-  pull_request
-]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [apb]
 
 env:
   PIP_CACHE_DIR: ~/.cache/pip

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -10,3 +10,6 @@ import_heading_firstparty=cisagov Libraries
 known_third_party=
 # These must be manually set to correctly separate them from third party libraries
 known_first_party=
+
+# Run isort under the black profile to align with our other Python linting
+profile=black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.1.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-json
@@ -27,7 +27,7 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.23.0
+    rev: v0.23.2
     hooks:
       - id: markdownlint
         args:
@@ -41,13 +41,13 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.1
+    rev: 3.8.3
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.4.1
+    rev: v2.7.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -61,20 +61,20 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.1.1
+    rev: v2.2.0
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21
+    rev: 5.0.7
     hooks:
       - id: isort
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.3.0a0
+    rev: v4.3.0a3
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.30.0
+    rev: v1.31.0
     hooks:
       - id: terraform_fmt
       # There are ongoing issues with how this command works. This issue
@@ -94,7 +94,7 @@ repos:
       # Terraform 0.13.
       # - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
-    rev: v1.0.1
+    rev: v2.0.0
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
@@ -102,6 +102,6 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.770
+    rev: v0.782
     hooks:
       - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,6 +89,9 @@ repos:
       # https://github.com/hashicorp/terraform/pull/24896
       # is a proprosed fix to deal with `terraform validate` with proxy
       # providers (among other configurations).
+      # We have decided to disable the terraform_validate hook until the issues
+      # above have been resolved, which we hope will be with the release of
+      # Terraform 0.13.
       # - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.0a2
+    rev: 3.8.1
     hooks:
       - id: flake8
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,10 +64,10 @@ repos:
     rev: v2.1.1
     hooks:
       - id: seed-isort-config
-  - repo: https://github.com/pre-commit/mirrors-isort
+  - repo: https://github.com/timothycrosley/isort
     # pick the isort version you'd like to use from
     # https://github.com/pre-commit/mirrors-isort/releases
-    rev: v4.3.21
+    rev: 4.3.21
     hooks:
       - id: isort
   - repo: https://github.com/ansible/ansible-lint.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,13 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.22.0
+    rev: v0.23.0
     hooks:
       - id: markdownlint
         args:
           - --config=.mdl_config.json
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.21.0
+    rev: v1.23.0
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
@@ -41,13 +41,13 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.0a2
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.1.0
+    rev: v2.4.1
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -61,7 +61,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.1.0
+    rev: v2.1.1
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/pre-commit/mirrors-isort
@@ -71,12 +71,12 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.2.0
+    rev: v4.3.0a0
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.29.0
+    rev: v1.30.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -85,7 +85,7 @@ repos:
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 2.0.4
+    rev: 2.0.5
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,19 @@ repos:
     rev: v1.30.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate
+      # There are ongoing issues with how this command works. This issue
+      # documents the core issue:
+      # https://github.com/hashicorp/terraform/issues/21408
+      # We have seen issues primarily with proxy providers and Terraform code
+      # that uses remote state. The PR
+      # https://github.com/hashicorp/terraform/pull/24887
+      # has been approved and is part of the 0.13 release to resolve the issue
+      # with remote states.
+      # The PR
+      # https://github.com/hashicorp/terraform/pull/24896
+      # is a proprosed fix to deal with `terraform validate` with proxy
+      # providers (among other configurations).
+      # - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,8 +65,6 @@ repos:
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/timothycrosley/isort
-    # pick the isort version you'd like to use from
-    # https://github.com/pre-commit/mirrors-isort/releases
     rev: 4.3.21
     hooks:
       - id: isort

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ If you already have `pyenv` and `pyenv-virtualenv` configured you can
 take advantage of the `setup-env` tool in this repo to automate the
 entire environment configuration process.
 
-```bash
+```console
 ./setup-env
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,8 +59,9 @@ environment.
 
 #### Installing and using `pyenv` and `pyenv-virtualenv` ####
 
-On the Mac, installation is as simple as `brew install pyenv
-pyenv-virtualenv` and adding this to your profile:
+On the Mac, we recommend installing [brew](https://brew.sh/).  Then
+installation is as simple as `brew install pyenv pyenv-virtualenv` and
+adding this to your profile:
 
 ```bash
 eval "$(pyenv init -)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,17 @@ There are a few ways to do this, but we prefer to use
 create and manage a Python virtual environment specific to this
 project.
 
+If you already have `pyenv` and `pyenv-virtualenv` configured you can
+take advantage of the `setup-env` tool in this repo to automate the
+entire environment configuration process.
+
+```bash
+./setup-env
+```
+
+Otherwise, follow the steps below to manually configure your
+environment.
+
 #### Installing and using `pyenv` and `pyenv-virtualenv` ####
 
 On the Mac, installation is as simple as `brew install pyenv

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/cisagov/ansible-role-remove-python2.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-remove-python2/alerts/)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/cisagov/ansible-role-remove-python2.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-remove-python2/context:python)
 
-An Ansible role for removing all python2 packages.
+An Ansible role for removing all python2 packages on all distributions
+other than Debian 9 (stretch).  Python2 is preserved on Debian 9 for
+the time being.
 
 ## Requirements ##
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/cisagov/ansible-role-remove-python2.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-remove-python2/alerts/)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/cisagov/ansible-role-remove-python2.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-remove-python2/context:python)
 
-An Ansible role for removing all python2 packages on all distributions
+An Ansible role for removing all Python2 packages on all distributions
 other than Debian 9 (stretch).  Python2 is preserved on Debian 9 for
 the time being.
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,12 +19,9 @@ galaxy_info:
         - bullseye
     - name: Fedora
       versions:
-        - 29
-        # Ansible currently insists on installing python2-dnf, which
-        # does not exist in Fedora 30.  Until that is resolved, we
-        # can't use Fedora 30.
-        # - 30
         - 31
+        - 32
+        - 33
     - name: Ubuntu
       versions:
         - bionic

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,7 +19,6 @@ galaxy_info:
         - bullseye
     - name: Fedora
       versions:
-        - 31
         - 32
         - 33
     - name: Ubuntu

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,16 +1,18 @@
 ---
 galaxy_info:
   author: Shane Frasier
-  description: Remove all python2 packages
+  description: >
+      Remove all python2 packages, except on AmazonLinux 2 and Debian
+      9 (Stretch)
   company: CISA Cyber Assessments
   license: CC0
   min_ansible_version: 2.0
   platforms:
     # Python2 is required for the version of yum used by Amazon Linux
     # 2.  Therefore python2 cannot be removved from this distribution.
-    # - name: Amazon
-    #   versions:
-    #     - 2
+    - name: Amazon
+      versions:
+        - 2
     - name: Debian
       versions:
         - stretch

--- a/molecule/default/Dockerfile_debian_9.j2
+++ b/molecule/default/Dockerfile_debian_9.j2
@@ -1,0 +1,12 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+ARG testarg=fail
+ENV envarg=$testarg
+
+RUN apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 python-apt aptitude && apt-get clean

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,15 +20,12 @@ platforms:
     image: debian:bullseye-slim
   - name: kali
     image: kalilinux/kali-rolling
-  - name: fedora29
-    image: fedora:29
-  # Ansible currently insists on installing python2-dnf, which does
-  # not exist in Fedora 30.  Until that is resolved, we can't use
-  # Fedora 30.
-  # - name: fedora30
-  #   image: fedora:30
   - name: fedora31
     image: fedora:31
+  - name: fedora32
+    image: fedora:32
+  - name: fedora33
+    image: fedora:33
   - name: ubuntu16
     image: ubuntu:xenial
   - name: ubuntu18

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,8 +20,6 @@ platforms:
     image: debian:bullseye-slim
   - name: kali
     image: kalilinux/kali-rolling
-  - name: fedora31
-    image: fedora:31
   - name: fedora32
     image: fedora:32
   - name: fedora33

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,10 +9,8 @@ lint: |
   ansible-lint
   flake8
 platforms:
-  # Python2 is required for the version of yum used by Amazon Linux 2.
-  # Therefore python2 cannot be removved from this distribution.
-  # - name: amazonlinux2
-  #   image: amazonlinux:2
+  - name: amazonlinux2
+    image: amazonlinux:2
   - name: debian9
     image: debian:stretch-slim
     dockerfile: Dockerfile_debian_9.j2

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -16,5 +16,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     "f", ["/usr/bin/python", "/usr/bin/python2", "/usr/bin/python2.7"]
 )
 def test_python(host, f):
-    """Ensure that python2-specific files no longer exist."""
-    assert not host.file(f).exists
+    """Ensure that python2-specific files no longer exist, except on Debian 9."""
+    if host.system_info.distribution == "debian" and host.system_info.release == "9.12":
+        assert host.file(f).exists
+    else:
+        assert not host.file(f).exists

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -17,10 +17,10 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     "f", ["/usr/bin/python", "/usr/bin/python2", "/usr/bin/python2.7"]
 )
 def test_python(host, f):
-    """Ensure that python2-specific files no longer exist, except on Debian 9."""
+    """Ensure that python2-specific files no longer exist, except on AmazonLinux or Debian 9."""
     # Note that r"^9(\.|$)" will match any string starting with "9.",
     # or the string "9".
-    if (
+    if host.system_info.distribution == "amzn" or (
         host.system_info.distribution == "debian"
         and re.match(r"^9(\.|$)", host.system_info.release) is not None
     ):

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -2,6 +2,7 @@
 
 # Standard Python Libraries
 import os
+import re
 
 # Third-Party Libraries
 import pytest
@@ -17,7 +18,12 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 )
 def test_python(host, f):
     """Ensure that python2-specific files no longer exist, except on Debian 9."""
-    if host.system_info.distribution == "debian" and host.system_info.release == "9.12":
+    # Note that r"^9(\.|$)" will match any string starting with "9.",
+    # or the string "9".
+    if (
+        host.system_info.distribution == "debian"
+        and re.match(r"^9(\.|$)", host.system_info.release) is not None
+    ):
         assert host.file(f).exists
     else:
         assert not host.file(f).exists

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,2 @@
+--requirement requirements.txt
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+setuptools
+wheel

--- a/setup-env
+++ b/setup-env
@@ -69,8 +69,9 @@ if [ -z "$(command -v pyenv)" ] || [ -z "$(command -v pyenv-virtualenv)" ]; then
   if [[ "$OSTYPE" == "darwin"* ]]; then
     cat << 'END_OF_LINE'
 
-  On the Mac, installation is as simple as "brew install pyenv
-  pyenv-virtualenv" and adding this to your profile:
+  On the Mac, we recommend installing brew, https://brew.sh/.  Then installation
+  is as simple as `brew install pyenv pyenv-virtualenv` and adding this to your
+  profile:
 
   eval "$(pyenv init -)"
   eval "$(pyenv virtualenv-init -)"

--- a/setup-env
+++ b/setup-env
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+USAGE=$(cat << 'END_OF_LINE'
+This script is used to configure a developement environment for this repo.
+
+It does the following:
+  - Verifies pyenv and pyenv-virtualenv are installed.
+  - Creates a Python virtual environment.
+  - Configures the activation of the virtual enviroment for the repo directory.
+  - Installs the requirements required for development.
+  - Installs git pre-commit hooks.
+  - Configures git upstream remote "lineage" repositories.
+
+usage: setup-env [--force] [--help] [virt_env_name]
+
+END_OF_LINE
+)
+
+# Flag to force deletion and creation of virtual environment
+FORCE=0
+
+# Positional parameters
+PARAMS=""
+
+# Parse command line arguments
+while (( "$#" )); do
+  case "$1" in
+    -f|--force)
+      FORCE=1
+      shift
+      ;;
+    -h|--help)
+      echo "${USAGE}"
+      exit 0
+      ;;
+    -*) # unsupported flags
+       echo "Error: Unsupported flag $1" >&2
+       exit 1
+       ;;
+    *) # preserve positional arguments
+       PARAMS="$PARAMS $1"
+       shift
+       ;;
+      esac
+done
+
+# set positional arguments in their proper place
+eval set -- "$PARAMS"
+
+# Check to see if pyenv is installed
+if [ -z "$(which pyenv)" ] || [ -z "$(which pyenv-virtualenv)" ]; then
+  echo "pyenv and pyenv-virtualenv are required."
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    cat << 'END_OF_LINE'
+
+  On the Mac, installation is as simple as "brew install pyenv
+  pyenv-virtualenv" and adding this to your profile:
+
+  eval "$(pyenv init -)"
+  eval "$(pyenv virtualenv-init -)"
+
+END_OF_LINE
+
+  fi
+  cat << 'END_OF_LINE'
+  For Linux, Windows Subsystem for Linux (WSL), or on the Mac (if you don't want
+  to use "brew") you can use https://github.com/pyenv/pyenv-installer to install
+  the necessary tools. Before running this ensure that you have installed the
+  prerequisites for your platform according to the pyenv wiki page,
+  https://github.com/pyenv/pyenv/wiki/common-build-problems.
+
+  On WSL you should treat your platform as whatever Linux distribution you've
+  chosen to install.
+
+  Once you have installed "pyenv" you will need to add the following lines to
+  your ".bashrc":
+
+  export PATH="$PATH:$HOME/.pyenv/bin"
+  eval "$(pyenv init -)"
+  eval "$(pyenv virtualenv-init -)"
+END_OF_LINE
+  exit 1
+fi
+
+set +o nounset
+# Determine the virtual environment name
+if [ "$1" ]; then
+  # Use the user-provided environment name
+  env_name=$1
+else
+  # Set the environment name to the last part of the working directory.
+  env_name=${PWD##*/}
+fi
+set -o nounset
+
+# Remove any lingering local configuration.
+if [ $FORCE -ne 0 ]; then
+  rm -f .python-version
+  pyenv virtualenv-delete --force "${env_name}" || true
+elif [[ -f .python-version ]]; then
+  cat << 'END_OF_LINE'
+  An existing .python-version file was found.  Either remove this file yourself
+  or re-run with --force option to have it deleted along with the associated
+  virtual environment.
+
+  rm .python-version
+
+END_OF_LINE
+  exit 1
+fi
+
+# Create a new virutal environment for this project
+if ! pyenv virtualenv "${env_name}"; then
+  cat << END_OF_LINE
+  An existing virtual environment named $env_name was found.  Either delete this
+  environment yourself or re-run with --force option to have it deleted.
+
+  pyenv virtualenv-delete ${env_name}
+
+END_OF_LINE
+  exit 1
+fi
+
+# Activate the new virtual environment
+pyenv local "${env_name}"
+
+# Upgrade pip and friends
+python -m pip install --upgrade pip setuptools wheel
+
+# Find a requirements file (if possible) and install
+for req_file in "requirements-dev.txt" "requirements-test.txt" "requirements.txt"; do
+  if [[ -f $req_file ]]
+  then
+    pip install -r $req_file
+    break
+  fi
+done
+
+# Install git pre-commit hooks
+pre-commit install
+
+# Setup git remotes from lineage configuration
+# This could fail if the remotes are already setup, but that is ok.
+set +o errexit
+
+eval "$(python3 << 'END_OF_LINE'
+from pathlib import Path
+import yaml
+import sys
+
+LINEAGE_CONFIG = Path(".github/lineage.yml")
+
+if not LINEAGE_CONFIG.exists():
+    print('No lineage configuration found.', file=sys.stderr)
+    sys.exit(0)
+
+with LINEAGE_CONFIG.open("r") as f:
+    lineage = yaml.safe_load(stream=f)
+
+if lineage["version"] == "1":
+    for parent_name, v in lineage["lineage"].items():
+        remote_url = v["remote-url"]
+        print(f"git remote add {parent_name} {remote_url};")
+        print(f"git remote set-url --push {parent_name} no_push;")
+else:
+    print(f'Unsupported lineage version: {lineage["version"]}', file=sys.stderr)
+END_OF_LINE
+)"
+
+# Qapla
+echo "Success!"

--- a/setup-env
+++ b/setup-env
@@ -37,6 +37,10 @@ PARAMS=""
 # Parse command line arguments
 while (( "$#" )); do
   case "$1" in
+    -i|--install-hooks)
+      INSTALL_HOOKS=1
+      shift
+      ;;
     -f|--force)
       FORCE=1
       shift
@@ -148,8 +152,8 @@ for req_file in "requirements-dev.txt" "requirements-test.txt" "requirements.txt
   fi
 done
 
-# Install git pre-commit hooks
-pre-commit install
+# Install git pre-commit hooks now or later.
+pre-commit install ${INSTALL_HOOKS:+"--install-hooks"}
 
 # Setup git remotes from lineage configuration
 # This could fail if the remotes are already setup, but that is ok.

--- a/setup-env
+++ b/setup-env
@@ -125,7 +125,8 @@ END_OF_LINE
   exit 1
 fi
 
-# Activate the new virtual environment
+# Set the local application-specific Python version(s) by writing the
+# version name to a file named `.python-version'.
 pyenv local "${env_name}"
 
 # Upgrade pip and friends

--- a/setup-env
+++ b/setup-env
@@ -134,9 +134,8 @@ python3 -m pip install --upgrade pip setuptools wheel
 
 # Find a requirements file (if possible) and install
 for req_file in "requirements-dev.txt" "requirements-test.txt" "requirements.txt"; do
-  if [[ -f $req_file ]]
-  then
-    pip install -r $req_file
+  if [[ -f $req_file ]]; then
+    pip install --requirement $req_file
     break
   fi
 done

--- a/setup-env
+++ b/setup-env
@@ -37,10 +37,6 @@ PARAMS=""
 # Parse command line arguments
 while (( "$#" )); do
   case "$1" in
-    -i|--install-hooks)
-      INSTALL_HOOKS=1
-      shift
-      ;;
     -f|--force)
       FORCE=1
       shift
@@ -48,6 +44,10 @@ while (( "$#" )); do
     -h|--help)
       echo "${USAGE}"
       exit 0
+      ;;
+    -i|--install-hooks)
+      INSTALL_HOOKS=1
+      shift
       ;;
     -*) # unsupported flags
        echo "Error: Unsupported flag $1" >&2

--- a/setup-env
+++ b/setup-env
@@ -168,7 +168,7 @@ import sys
 LINEAGE_CONFIG = Path(".github/lineage.yml")
 
 if not LINEAGE_CONFIG.exists():
-    print('No lineage configuration found.', file=sys.stderr)
+    print("No lineage configuration found.", file=sys.stderr)
     sys.exit(0)
 
 with LINEAGE_CONFIG.open("r") as f:

--- a/setup-env
+++ b/setup-env
@@ -113,7 +113,7 @@ END_OF_LINE
   exit 1
 fi
 
-# Create a new virutal environment for this project
+# Create a new virtual environment for this project
 if ! pyenv virtualenv "${env_name}"; then
   cat << END_OF_LINE
   An existing virtual environment named $env_name was found.  Either delete this

--- a/setup-env
+++ b/setup-env
@@ -64,7 +64,7 @@ done
 eval set -- "$PARAMS"
 
 # Check to see if pyenv is installed
-if [ -z "$(which pyenv)" ] || [ -z "$(which pyenv-virtualenv)" ]; then
+if [ -z "$(command -v pyenv)" ] || [ -z "$(command -v pyenv-virtualenv)" ]; then
   echo "pyenv and pyenv-virtualenv are required."
   if [[ "$OSTYPE" == "darwin"* ]]; then
     cat << 'END_OF_LINE'

--- a/setup-env
+++ b/setup-env
@@ -130,7 +130,7 @@ fi
 pyenv local "${env_name}"
 
 # Upgrade pip and friends
-python -m pip install --upgrade pip setuptools wheel
+python3 -m pip install --upgrade pip setuptools wheel
 
 # Find a requirements file (if possible) and install
 for req_file in "requirements-dev.txt" "requirements-test.txt" "requirements.txt"; do

--- a/setup-env
+++ b/setup-env
@@ -16,7 +16,7 @@ It does the following:
   - Configures git upstream remote "lineage" repositories.
 
 Usage:
-  setup-env [--force] [virt_env_name]
+  setup-env [options] [virt_env_name]
   setup-env (-h | --help)
 
 Options:

--- a/setup-env
+++ b/setup-env
@@ -5,17 +5,25 @@ set -o errexit
 set -o pipefail
 
 USAGE=$(cat << 'END_OF_LINE'
-This script is used to configure a developement environment for this repo.
+Configure a developement environment for this repository.
 
 It does the following:
   - Verifies pyenv and pyenv-virtualenv are installed.
   - Creates a Python virtual environment.
   - Configures the activation of the virtual enviroment for the repo directory.
-  - Installs the requirements required for development.
+  - Installs the requirements needed for development.
   - Installs git pre-commit hooks.
   - Configures git upstream remote "lineage" repositories.
 
-usage: setup-env [--force] [--help] [virt_env_name]
+Usage:
+  setup-env [--force] [virt_env_name]
+  setup-env (-h | --help)
+
+Options:
+  -f --force          Delete virtual enviroment if it already exists.
+  -h --help           Show this message.
+  -i --install-hooks  Install hook environments for all environments in the
+                      pre-commit config file.
 
 END_OF_LINE
 )

--- a/tasks/remove_Amazon.yml
+++ b/tasks/remove_Amazon.yml
@@ -1,0 +1,6 @@
+---
+- name: Do nothing
+  assert:
+    that:
+      - true
+    quiet: yes

--- a/tasks/remove_Debian_9.12.yml
+++ b/tasks/remove_Debian_9.12.yml
@@ -1,0 +1,1 @@
+remove_Debian_9.yml

--- a/tasks/remove_Debian_9.13.yml
+++ b/tasks/remove_Debian_9.13.yml
@@ -1,0 +1,1 @@
+remove_Debian_9.yml

--- a/tasks/remove_Debian_9.yml
+++ b/tasks/remove_Debian_9.yml
@@ -1,6 +1,1 @@
----
-- name: Do nothing
-  assert:
-    that:
-      - true
-    quiet: yes
+remove_Amazon.yml

--- a/tasks/remove_Debian_9.yml
+++ b/tasks/remove_Debian_9.yml
@@ -1,0 +1,6 @@
+---
+- name: Do nothing
+  assert:
+    that:
+      - true
+    quiet: yes


### PR DESCRIPTION
## 🗣 Description

This pull request:
* Pulls in upstream changes
* Changes the Ansible role so that nothing is done on Debian 9.  In other words, python2 is preserved on Debian 9.

## 💭 Motivation and Context

In cisagov/ansible-role-bloodhound#7 I added to the molecule prepare playbook the update and python playbooks that we normally run via packer before building up a COOL AMI.  (See [here](https://github.com/cisagov/guacamole-packer/blob/develop/src/packer.json#L65-L79), for example.)  This gives molecule a more realistic base from which to start applying Ansible roles, so I also want to backport these additions to [cisagov/skeleton-ansible-role](https://github.com/cisagov/skeleton-ansible-role).

@mcdonnnj is fine with adding the upgrade and python playbooks to the CyHy packer code, and he is also fine with adding them to the CyHy Ansible roles _as they are upgraded to python3_.  Since the CyHy AMIs and Ansible roles will drop support for Debian 9 and move to Debian 10 as part of the python3 upgrade, having this Ansible role preserve python2 on Debian 9 will stop our lineage and apb tools from forcing his hand before he is ready.  That is the context and motivation for these changes.

## 🧪 Testing

All pre-commit hooks pass.  I modified the molecule tests to check that Python2 is preserved on Debian 9, then verified that the modified tests pass after these changes.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
