### PR TITLE
Use FQCNs and replace deprecated usage of `ansible.builtin.include`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for remove-python2
 
 - name: Load var file with package names based on the OS type
-  include_vars: "{{ lookup('first_found', params) }}"
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:
     params:
       files:
@@ -13,7 +13,7 @@
         - "{{ role_path }}/vars"
 
 - name: Load tasks file with install tasks based on the OS type
-  include: "{{ lookup('first_found', params) }}"
+  ansible.builtin.include: "{{ lookup('first_found', params) }}"
   vars:
     params:
       files:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
         - "{{ role_path }}/vars"
 
 - name: Load tasks file with install tasks based on the OS type
-  ansible.builtin.include: "{{ lookup('first_found', params) }}"
+  ansible.builtin.include_tasks: "{{ lookup('first_found', params) }}"
   vars:
     params:
       files:

--- a/tasks/remove_Amazon.yml
+++ b/tasks/remove_Amazon.yml
@@ -1,6 +1,6 @@
 ---
 - name: Do nothing
-  assert:
+  ansible.builtin.assert:
     that:
       - true
     quiet: yes

--- a/tasks/remove_Debian.yml
+++ b/tasks/remove_Debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Remove python2 (Debian)
-  apt:
+  ansible.builtin.apt:
     name: "{{ package_names }}"
     state: absent
     # This gets rid of any dangling python2 packages

--- a/tasks/remove_RedHat.yml
+++ b/tasks/remove_RedHat.yml
@@ -1,6 +1,6 @@
 ---
 - name: Remove python2 (RedHat)
-  dnf:
+  ansible.builtin.dnf:
     name: "{{ package_names }}"
     state: absent
     # This gets rid of any dangling python2 packages


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR does two simple things:

- Use fully-qualified class names for packages
- Replace the deprecated `ansible.builtin.include` with the suitable `ansible.builtin.include_tasks`
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We have been switching to using FQCNs per Ansible guidance in all of our projects and anything using this role currently outputs deprecation warnings about using `include`.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
