### PR TITLE
Do not remove Python 2 on Debian Buster

### DIFF
--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,7 +1,9 @@
 ---
 - src: https://github.com/cisagov/ansible-role-pip
   name: pip
+  version: change/install_pip_on_debian_buster
 - src: https://github.com/cisagov/ansible-role-python
   name: python
+  version: change/install_python2_on_debian_buster
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -2,7 +2,6 @@
 
 # Standard Python Libraries
 import os
-import re
 
 # Third-Party Libraries
 import pytest
@@ -17,12 +16,15 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     "f", ["/usr/bin/python", "/usr/bin/python2", "/usr/bin/python2.7"]
 )
 def test_python(host, f):
-    """Ensure that python2-specific files no longer exist, except on AmazonLinux or Debian 9."""
+    """Ensure that python2-specific files no longer exist, except on AmazonLinux or Debian 9/10."""
     # Note that r"^9(\.|$)" will match any string starting with "9.",
     # or the string "9".
     if host.system_info.distribution == "amzn" or (
         host.system_info.distribution == "debian"
-        and re.match(r"^9(\.|$)", host.system_info.release) is not None
+        and (
+            host.system_info.codename == "stretch"
+            or host.system_info.codename == "buster"
+        )
     ):
         assert host.file(f).exists
     else:

--- a/tasks/remove_Debian_buster.yml
+++ b/tasks/remove_Debian_buster.yml
@@ -1,0 +1,1 @@
+remove_Amazon.yml


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates this role to not remove Python 2 if run against Debian Buster systems.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is the last piece of the work related to https://github.com/cisagov/ansible-role-python/pull/45 and https://github.com/cisagov/ansible-role-pip/pull/48 to support Debian Buster AMIs in [cisagov/cyhy_amis](https://github.com/cisagov/cyhy_amis).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I have this integrated in my testing environment and I confirmed that Debian Buster AMIs had Python 2 once I deployed instances using them.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
