### PR TITLE
Mention that Python 2 is also preserved for Amazon Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/cisagov/ansible-role-remove-python2.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-remove-python2/alerts/)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/cisagov/ansible-role-remove-python2.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-remove-python2/context:python)
 
-An Ansible role for removing all Python2 packages on all distributions
-other than Debian 9 (stretch) and Amazon Linux.  Python2 is preserved
+An Ansible role for removing all Python 2 packages on all distributions
+other than Debian 9 (stretch) and Amazon Linux.  Python 2 is preserved
 on Debian 9 for the time being, and Amazon Linux requires Python 2 for
 its outdated `yum` command.
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/cisagov/ansible-role-remove-python2.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-remove-python2/context:python)
 
 An Ansible role for removing all Python2 packages on all distributions
-other than Debian 9 (stretch).  Python2 is preserved on Debian 9 for
-the time being.
+other than Debian 9 (stretch) and Amazon Linux.  Python2 is preserved
+on Debian 9 for the time being, and Amazon Linux requires Python 2 for
+its outdated `yum` command.
 
 ## Requirements ##
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the README to mentioned that Python 2 is also preserved for Amazon Linux.

## 💭 Motivation and context ##

Amazon Linux requires Python 2 for its outdated `yum` command.

## 🧪 Testing ##

All automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.