### PR TITLE
Update Python 2 removal logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/cisagov/ansible-role-remove-python2.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-remove-python2/context:python)
 
 An Ansible role for removing all Python 2 packages on all distributions
-other than Debian 9 (stretch) and Amazon Linux.  Python 2 is preserved
-on Debian 9 for the time being, and Amazon Linux requires Python 2 for
-its outdated `yum` command.
+other than Amazon Linux 2.  Python 2 is preserved on Amazon Linux 2
+because its outdated `yum` command requires Python 2.
 
 ## Requirements ##
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Here's how to use it in a playbook:
   become: yes
   become_method: sudo
   roles:
-    - no_python2
+    - remove_python2
 ```
 
 ## Contributing ##

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,9 +1,7 @@
 ---
 galaxy_info:
   author: Shane Frasier
-  description: >
-      Remove all python2 packages, except on AmazonLinux 2 and Debian
-      9 (Stretch)
+  description: Remove all python2 packages, except on AmazonLinux 2
   company: CISA Cyber Assessments
   galaxy_tags:
     - python

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,7 +16,7 @@ galaxy_info:
   namespace: cisagov
   platforms:
     # Python 2 is required for the version of yum used by Amazon Linux
-    # 2.  Therefore Python 2 cannot be removved from this distribution.
+    # 2.  Therefore Python 2 cannot be removed from this distribution.
     - name: Amazon
       versions:
         - 2

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Shane Frasier
-  description: Remove all python2 packages, except on AmazonLinux 2
+  description: Remove all Python 2 packages, except on Amazon Linux 2
   company: CISA Cyber Assessments
   galaxy_tags:
     - python
@@ -15,8 +15,8 @@ galaxy_info:
   min_ansible_version: 2.10
   namespace: cisagov
   platforms:
-    # Python2 is required for the version of yum used by Amazon Linux
-    # 2.  Therefore python2 cannot be removved from this distribution.
+    # Python 2 is required for the version of yum used by Amazon Linux
+    # 2.  Therefore Python 2 cannot be removved from this distribution.
     - name: Amazon
       versions:
         - 2

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -2,10 +2,8 @@
 
 # Standard Python Libraries
 import os
-import re
 
 # Third-Party Libraries
-import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
@@ -13,17 +11,47 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-@pytest.mark.parametrize(
-    "f", ["/usr/bin/python", "/usr/bin/python2", "/usr/bin/python2.7"]
-)
-def test_python(host, f):
-    """Ensure that python2-specific files no longer exist, except on AmazonLinux or Debian 9."""
-    # Note that r"^9(\.|$)" will match any string starting with "9.",
-    # or the string "9".
-    if host.system_info.distribution == "amzn" or (
-        host.system_info.distribution == "debian"
-        and re.match(r"^9(\.|$)", host.system_info.release) is not None
-    ):
-        assert host.file(f).exists
+def test_python2_files(host):
+    """Ensure that Python 2-specific files no longer exist, except on Amazon Linux 2."""
+    python2_files = ["/usr/bin/python", "/usr/bin/python2", "/usr/bin/python2.7"]
+    # Python 2 is required for the old version of yum used on Amazon Linux 2 so
+    # these paths should still exist on that platform.
+    if host.system_info.distribution == "amzn":
+        for file in python2_files:
+            assert host.file(file).exists
+    elif host.system_info.distribution in ["debian", "fedora", "kali", "ubuntu"]:
+        for file in python2_files:
+            assert not host.file(file).exists
     else:
-        assert not host.file(f).exists
+        assert (
+            False
+        ), f"Linux distribution {host.system_info.distribution} is not supported."
+
+
+def test_python2_packages(host):
+    """Ensure that no Python 2-specific packages are installed, except on Amazon Linux 2."""
+    # Since we do not want any of these installed we can safely combine them all
+    # into one comprehensive list.
+    python2_packages = [
+        "python-dev",
+        "python-minimal",
+        "python-unversioned-command",
+        "python",
+        "python2-dev",
+        "python2-minimal",
+        "python2.7",
+        "python2",
+    ]
+    # This should remain installed as it is required for the old version of yum
+    # used by Amazon Linux 2.
+    amazonlinux2_packages = ["python"]
+    if host.system_info.distribution == "amzn":
+        for package in amazonlinux2_packages:
+            assert host.package(package).is_installed
+    elif host.system_info.distribution in ["debian", "fedora", "kali", "ubuntu"]:
+        for package in python2_packages:
+            assert not host.package(package).is_installed
+    else:
+        assert (
+            False
+        ), f"Linux distribution {host.system_info.distribution} is not supported."

--- a/tasks/remove_Debian.yml
+++ b/tasks/remove_Debian.yml
@@ -1,7 +1,7 @@
 ---
-- name: Remove python2 (Debian)
+- name: Remove Python 2 (Debian)
   ansible.builtin.apt:
     name: "{{ package_names }}"
     state: absent
-    # This gets rid of any dangling python2 packages
+    # This gets rid of any dangling Python 2 packages
     autoremove: yes

--- a/tasks/remove_Debian_stretch.yml
+++ b/tasks/remove_Debian_stretch.yml
@@ -1,1 +1,0 @@
-remove_Amazon.yml

--- a/tasks/remove_RedHat.yml
+++ b/tasks/remove_RedHat.yml
@@ -1,7 +1,7 @@
 ---
-- name: Remove python2 (RedHat)
+- name: Remove Python 2 (RedHat)
   ansible.builtin.dnf:
     name: "{{ package_names }}"
     state: absent
-    # This gets rid of any dangling python2 packages
+    # This gets rid of any dangling Python 2 packages
     autoremove: yes

--- a/vars/Debian_stretch.yml
+++ b/vars/Debian_stretch.yml
@@ -1,9 +1,9 @@
 ---
 # The Python 2 package names
 package_names:
-  - python2
-  - python2-dev
+  - python
+  - python-dev
   # This is the package that actually provides /usr/bin/python.  We
   # want /usr/bin/python to not exist, since if it does then Ansible
   # will use it as its python.
-  - python2-minimal
+  - python-minimal

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,8 +1,5 @@
 ---
-# vars file for RedHat
-
-# The Python2 package names
+# The Python 2 package names
 package_names:
   - python-unversioned-command
-  - python2
-  - python2-devel
+  - python2.7

--- a/vars/Ubuntu_bionic.yml
+++ b/vars/Ubuntu_bionic.yml
@@ -1,0 +1,1 @@
+Debian_stretch.yml


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request does the following:
- Update the packages that will be removed to reflect the packages available on our currently supported platforms.
- Update so that all platforms except Amazon Linux 2 have Python 2-related packages removed.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The package names currently in this role do not reflect the package names for Python 2 on our currently supported platforms.

The hidden logic of allowing Python 2 to remain on certain platforms because of non-platform reasons is not a very clear development pattern. With this PR's changes in place this role should only be used when you do not want Python 2 on the target machine no matter the OS (except Amazon Linux 2 for platform-specific reasons). I think this makes it much clearer what will and will not be on a resultant build than the current configuration.

Note: Although Debian Buster shares package names for Python 2 with Debian Stretch, the `python2` package names are compatible with Debian Buster and are what is used on Debian Bullseye and Debian Bookworm.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
